### PR TITLE
Fixed spurious printing on garbage collection of sockets.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,5 @@
 Package: pbdZMQ
-Version: 0.1-2
-Date: 2015-09-26
+Version: 0.2-0
 Title: Programming with Big Data -- Interface to 'ZeroMQ'
 Authors@R: c(person("Wei-Chen", "Chen", role = c("aut", "cre"), email =
         "wccsnow@gmail.com"),
@@ -36,10 +35,3 @@ MailingList: Please send questions and comments regarding pbdR to
 NeedsCompilation: yes
 ByteCompile: yes
 Maintainer: Wei-Chen Chen <wccsnow@gmail.com>
-Packaged: 2015-10-03 02:06:48 UTC; snoweye
-Author: Wei-Chen Chen [aut, cre],
-  Drew Schmidt [aut],
-  Whit Armstrong [ctb] (some functions are modified from the rzmq package
-    for backwards compatibility),
-  Brian Ripley [ctb] (C code of shellexec),
-  R Core team [ctb] (some functions are modified from the R source code)

--- a/R/rzmq_wrapper.r
+++ b/R/rzmq_wrapper.r
@@ -84,7 +84,7 @@ receive.socket <- function(socket, unserialize = TRUE, dont.wait = FALSE){
 #' @export
 init.context <- function(){
   try.zmq.ctx.destroy <- function(ctx){
-    try(zmq.ctx.destroy(ctx), silent = TRUE)
+    invisible(tryCatch(zmq.ctx.destroy(ctx), warning=identity))
   }
   
   ctx <- zmq.ctx.new()  

--- a/R/rzmq_wrapper.r
+++ b/R/rzmq_wrapper.r
@@ -89,7 +89,7 @@ init.context <- function(){
   
   ctx <- zmq.ctx.new()  
   reg.finalizer(ctx, try.zmq.ctx.destroy, onexit = TRUE)
-  ctx
+  ctx 
 }
 
 
@@ -98,7 +98,7 @@ init.context <- function(){
 #' @export
 init.socket <- function(context, socket.type){
   try.zmqt.close <- function(socket){
-    try(zmq.close(socket), silent = TRUE)
+    invisible(tryCatch(zmq.close(socket), warning=identity))
   }
   
   socket.type <- sub(".*_", "", socket.type)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pbdZMQ
 
-* **Version:** 0.1-2
+* **Version:** 0.2-0
 * **License:** GPL-3
 * **Author:** See section below.
 

--- a/README.md
+++ b/README.md
@@ -34,37 +34,38 @@ very basic.  You can see a more detailed example in the pbdZMQ
 package vignette.
 
 
-#### Setting Up The Server
+#### Server
 
 Save the following as, say, `server.r` and run it in batch by 
 running `Rscript server.r` from a terminal.
 
 ```r
 library(pbdZMQ)
-ctxt <- init.context()
-socket <- init.socket(ctxt, "ZMQ_REP")
-bind.socket(socket, "tcp://*:5555")
+context = zmq$Context()
+socket = context$socket("ZMQ_REP")
+socket$bind("tcp://*:55555")
 
 cat("Client command:  ")
-msg <- receive.socket(socket)
+msg <- socket$receive()
 
 cat(msg, "\n")
-send.socket(socket, "Message received!")
+socket$send("Message received!")
 ```
 
 
-#### Setting Up The Client
+#### Client
 
 From an interactive R session (not in batch), enter the
 following:
 
 ```r
 library(pbdZMQ)
-ctxt <- init.context()
-socket <- init.socket(ctxt, "ZMQ_REQ")
-connect.socket(socket, "tcp://localhost:5555")
+context = zmq$Context()
+socket = context$socket("ZMQ_REQ")
+socket$connect("tcp://localhost:55555")
 
-send.socket(socket, "1+1")
+socket$send("1+1")
+socket$receive()
 ```
 
 If all goes well, your message should be sent from the client

--- a/src/R_zmq_context.c
+++ b/src/R_zmq_context.c
@@ -2,22 +2,7 @@
 
 
 /* Context related. */
-/* Use R level reg.finalizer to handle this and avoid seg. fault.
-static void ctx_Finalizer(SEXP R_context){
-	int C_ret = -1, C_errno;
-	void *C_context = R_ExternalPtrAddr(R_context);
-
-	if(C_context != NULL){
-		C_ret = zmq_ctx_destroy(C_context);
-		// No need to cast error at the end of R.
-		// if(C_ret == -1){
-		// 	C_errno = zmq_errno();
-		// 	REprintf("ctx_Finalizer errno: %d strerror: %s\n",
-		// 		C_errno, zmq_strerror(C_errno));
-		// }
-		R_ClearExternalPtr(R_context);
-	}
-}*/ /* End of ctx_Finalizer(). */
+/* Use R level reg.finalizer to handle this and avoid seg. fault. */
 
 SEXP R_zmq_ctx_new(){
 	SEXP R_context = R_NilValue;
@@ -28,7 +13,7 @@ SEXP R_zmq_ctx_new(){
 		// R_RegisterCFinalizerEx(R_context, ctx_Finalizer, TRUE);
 		UNPROTECT(1);
 	} else{
-		REprintf("R_zmq_ctx_new: R_context is not available.\n");
+		warning("R_zmq_ctx_new: R_context is not available.\n");
 	}
 	return(R_context);
 } /* End of Rzmq_ctx_new(). */
@@ -44,7 +29,7 @@ SEXP R_zmq_ctx_destroy(SEXP R_context){
 	C_ret = zmq_ctx_destroy(C_context);
 	if(C_ret == -1){
 		C_errno = zmq_errno();
-		REprintf("R_zmq_ctx_destroy errno: %d strerror: %s\n",
+		warning("R_zmq_ctx_destroy errno: %d strerror: %s\n",
 			C_errno, zmq_strerror(C_errno));
 	}
 	return(AsInt(C_ret));

--- a/src/R_zmq_message.c
+++ b/src/R_zmq_message.c
@@ -17,7 +17,7 @@ SEXP R_zmq_msg_init(){
 		UNPROTECT(1);
 	} else{
 		C_errno = zmq_errno();
-		REprintf("R_zmq_msg_init errno: %d strerror: %s\n",
+		warning("R_zmq_msg_init errno: %d strerror: %s\n",
 			C_errno, zmq_strerror(C_errno));
 	}
 	return(R_msg_t);
@@ -34,7 +34,7 @@ SEXP R_zmq_msg_close(SEXP R_msg_t){
 	C_ret = zmq_msg_close(&C_msg_t);
 	if(C_ret == -1){
 		C_errno = zmq_errno();
-		REprintf("R_zmq_msg_close errno: %d stderror: %s\n",
+		warning("R_zmq_msg_close errno: %d stderror: %s\n",
 			C_errno, zmq_strerror(C_errno));
 	}
 	return(AsInt(C_ret));
@@ -50,7 +50,7 @@ SEXP R_zmq_msg_send(SEXP R_rmsg, SEXP R_socket, SEXP R_flags){
 		C_ret = zmq_msg_init_size(&msg, C_rmsg_length);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_msg_init_size errno: %d strerror: %s\n",
+			warning("R_zmq_msg_init_size errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 		memcpy(zmq_msg_data(&msg), RAW(R_rmsg), C_rmsg_length);
@@ -58,18 +58,18 @@ SEXP R_zmq_msg_send(SEXP R_rmsg, SEXP R_socket, SEXP R_flags){
 		C_ret = zmq_msg_send(&msg, C_socket, C_flags);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_msg_send errno: %d strerror: %s\n",
+			warning("R_zmq_msg_send errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 
 		C_ret = zmq_msg_close(&msg);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_msg_close errno: %d strerror: %s\n",
+			warning("R_zmq_msg_close errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 	} else{
-		REprintf("R_zmq_send: C_socket is not available.\n");
+		warning("R_zmq_send: C_socket is not available.\n");
 	}
 
 	return(R_NilValue);
@@ -86,14 +86,14 @@ SEXP R_zmq_msg_recv(SEXP R_socket, SEXP R_flags){
 		C_ret = zmq_msg_init(&msg);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_msg_init errno: %d strerror: %s\n",
+			warning("R_zmq_msg_init errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 
 		C_ret = zmq_msg_recv(&msg, C_socket, C_flags);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_msg_recv errno: %d strerror: %s\n",
+			warning("R_zmq_msg_recv errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 		C_rmsg_length = zmq_msg_size(&msg);
@@ -103,14 +103,14 @@ SEXP R_zmq_msg_recv(SEXP R_socket, SEXP R_flags){
 		C_ret = zmq_msg_close(&msg);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_msg_close errno: %d strerror: %s\n",
+			warning("R_zmq_msg_close errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 
 		UNPROTECT(1);
 		return(R_rmsg);
 	} else{
-		REprintf("R_zmq_send: C_socket is not available.\n");
+		warning("R_zmq_send: C_socket is not available.\n");
 	}
 
 	return(R_rmsg);

--- a/src/R_zmq_sendrecv.c
+++ b/src/R_zmq_sendrecv.c
@@ -11,11 +11,11 @@ SEXP R_zmq_send(SEXP R_socket, void *C_buf, SEXP R_len, SEXP R_flags){
 		C_ret = zmq_send(C_socket, C_buf, C_len, C_flags);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_send errno: %d strerror: %s\n",
+			warning("R_zmq_send errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 	} else{
-		REprintf("R_zmq_send: C_socket is not available.\n");
+		warning("R_zmq_send: C_socket is not available.\n");
 	}
 	return(AsInt(C_ret));
 } /* End of R_zmq_send(). */
@@ -39,11 +39,11 @@ int R_zmq_recv(SEXP R_socket, void *C_buf, SEXP R_len, SEXP R_flags){
 		C_ret = zmq_recv(C_socket, C_buf, C_len, C_flags);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_recv errno: %d strerror: %s\n",
+			warning("R_zmq_recv errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 	} else{
-		REprintf("R_zmq_recv: C_socket is not available.\n");
+		warning("R_zmq_recv: C_socket is not available.\n");
 	}
 	return(C_ret);
 } /* End of R_zmq_recv(). */

--- a/src/R_zmq_socket.c
+++ b/src/R_zmq_socket.c
@@ -2,23 +2,7 @@
 
 
 /* Socket related. */
-/* Use R level reg.finalizer to handle this and avoid seg. fault.
-static void socket_Finalizer(SEXP R_socket){
-	int C_ret = -1, C_errno;
-	void *C_socket = R_ExternalPtrAddr(R_socket);
-
-	if(C_socket != NULL){
-		C_ret = zmq_close(C_socket);
-		// No need to cast error at the end of R.
-		//if(C_ret == -1){
-		//	C_errno = zmq_errno();
-		//	REprintf("socket_Finalizer errno: %d strerror: %s\n",
-		//		C_errno, zmq_strerror(C_errno));
-		//}
-
-		R_ClearExternalPtr(R_socket);
-	}
-}*/ /* End of socket_Finalizer(). */
+/* Use R level reg.finalizer to handle this and avoid seg. fault. */
 
 SEXP R_zmq_socket(SEXP R_context, SEXP R_type){
 	SEXP R_socket = R_NilValue;
@@ -34,10 +18,10 @@ SEXP R_zmq_socket(SEXP R_context, SEXP R_type){
 			// R_RegisterCFinalizerEx(R_socket, socket_Finalizer, TRUE);
 			UNPROTECT(1);
 		} else{
-			REprintf("R_zmq_socket: R_socket is not available.\n");
+			warning("R_zmq_socket: R_socket is not available.\n");
 		}
 	} else{
-		REprintf("R_zmq_socket: C_context is not available.\n");
+		warning("R_zmq_socket: C_context is not available.\n");
 	}
 	return(R_socket);
 } /* End of R_zmq_socket(). */
@@ -53,7 +37,7 @@ SEXP R_zmq_close(SEXP R_socket){
 	C_ret = zmq_close(C_socket);
 	if(C_ret == -1){
 		C_errno = zmq_errno();
-		REprintf("R_zmq_socket_close errno: %d strerror: %s\n",
+		warning("R_zmq_socket_close errno: %d strerror: %s\n",
 			C_errno, zmq_strerror(C_errno));
 	}
 	return(AsInt(C_ret));
@@ -68,11 +52,11 @@ SEXP R_zmq_bind(SEXP R_socket, SEXP R_endpoint){
 		C_ret = zmq_bind(C_socket, C_endpoint);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_bind errno: %d strerror: %s\n",
+			warning("R_zmq_bind errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 	} else{
-		REprintf("R_zmq_bind: C_socket is not available.\n");
+		warning("R_zmq_bind: C_socket is not available.\n");
 	}
 	return(AsInt(C_ret));
 } /* End of R_zmq_bind(). */
@@ -86,11 +70,11 @@ SEXP R_zmq_connect(SEXP R_socket, SEXP R_endpoint){
 		C_ret = zmq_connect(C_socket, C_endpoint);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_connect errno: %d strerror: %s\n",
+			warning("R_zmq_connect errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 	} else{
-		REprintf("R_zmq_connect: C_socket is not available.\n");
+		warning("R_zmq_connect: C_socket is not available.\n");
 	}
 	return(AsInt(C_ret));
 } /* End of R_zmq_connect(). */
@@ -104,11 +88,11 @@ SEXP R_zmq_disconnect(SEXP R_socket, SEXP R_endpoint){
 		C_ret = zmq_disconnect(C_socket, C_endpoint);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_disconnect errno: %d strerror: %s\n",
+			warning("R_zmq_disconnect errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 	} else{
-		REprintf("R_zmq_disconnect: C_socket is not available.\n");
+		warning("R_zmq_disconnect: C_socket is not available.\n");
 	}
 	return(AsInt(C_ret));
 } /* End of R_zmq_disconnect(). */
@@ -133,7 +117,7 @@ SEXP R_zmq_setsockopt(SEXP R_socket, SEXP R_option_name, SEXP R_option_value,
 				C_option_len = sizeof(int);
 				break;
 			default:
-				REprintf("C_option_type: %d is not implemented.\n",
+				warning("C_option_type: %d is not implemented.\n",
 					C_option_type);
 		} // End of switch().
 
@@ -141,11 +125,11 @@ SEXP R_zmq_setsockopt(SEXP R_socket, SEXP R_option_name, SEXP R_option_value,
 				C_option_value, C_option_len);
 		if(C_ret == -1){
 			C_errno = zmq_errno();
-			REprintf("R_zmq_setsockopt errno: %d strerror: %s\n",
+			warning("R_zmq_setsockopt errno: %d strerror: %s\n",
 				C_errno, zmq_strerror(C_errno));
 		}
 	} else{
-		REprintf("R_zmq_connect: C_socket is not available.\n");
+		warning("R_zmq_connect: C_socket is not available.\n");
 	}
 	return(AsInt(C_ret));
 } /* End of R_zmq_setsockopt(). */

--- a/src/shellexec_wcc.c
+++ b/src/shellexec_wcc.c
@@ -46,11 +46,11 @@ wchar_t *filenameToWchar_wcc(const SEXP fn, const Rboolean expand){
 
 	if(IS_LATIN1(fn)) from = "latin1";
 	if(IS_UTF8(fn)) from = "UTF-8";
-	if(IS_BYTES(fn)) REprintf("encoding of a filename cannot be 'bytes'");
+	if(IS_BYTES(fn)) warning("encoding of a filename cannot be 'bytes'");
 
 	obj = Riconv_open("UCS-2LE", from);
 	if(obj == (void *)(-1))
-		REprintf("unsupported conversion from '%s' in shellexec_wcc.c",
+		warning("unsupported conversion from '%s' in shellexec_wcc.c",
 			  from);
 
 	if(expand) inbuf = R_ExpandFileName(CHAR(fn)); else inbuf = CHAR(fn);
@@ -59,8 +59,8 @@ wchar_t *filenameToWchar_wcc(const SEXP fn, const Rboolean expand){
 	outbuf = (char *) filename;
 	res = Riconv(obj, &inbuf , &inb, &outbuf, &outb);
 	Riconv_close(obj);
-	if(inb > 0) REprintf("file name conversion problem -- name too long?");
-	if(res == -1) REprintf("file name conversion problem");
+	if(inb > 0) warning("file name conversion problem -- name too long?");
+	if(res == -1) warning("file name conversion problem");
 
 	return filename;
 } /* End of filenameToWchar_wcc(). */
@@ -76,7 +76,7 @@ static void internal_shellexecW_wcc(const wchar_t * file, Rboolean rhome,
 
 	if(rhome){
 		home = _wgetenv(L"R_HOME");
-		if(home == NULL) REprintf("R_HOME not set");
+		if(home == NULL) warning("R_HOME not set");
 		wcsncpy(home2, home, 10000);
 		for(p = home2; *p; p++) if(*p == L'/') *p = L'\\';
 		home = home2;
@@ -89,13 +89,13 @@ static void internal_shellexecW_wcc(const wchar_t * file, Rboolean rhome,
 	if(ret <= 32){ /* an error condition */
 		if(ret == ERROR_FILE_NOT_FOUND || ret == ERROR_PATH_NOT_FOUND
 		   || ret == SE_ERR_FNF || ret == SE_ERR_PNF)
-			REprintf("'%ls' not found", file);
+			warning("'%ls' not found", file);
 		if(ret == SE_ERR_ASSOCINCOMPLETE || ret == SE_ERR_NOASSOC)
-			REprintf("file association for '%ls' not available or invalid",
+			warning("file association for '%ls' not available or invalid",
 				file);
 		if(ret == SE_ERR_ACCESSDENIED || ret == SE_ERR_SHARE)
-			REprintf("access to '%ls' denied", file);
-		REprintf("problem in displaying '%ls'", file);
+			warning("access to '%ls' denied", file);
+		warning("problem in displaying '%ls'", file);
 	}
 #endif
 } /* End of internal_shellexecW_wcc().*/

--- a/tests/pyzmq.R
+++ b/tests/pyzmq.R
@@ -1,0 +1,23 @@
+library(pbdZMQ)
+
+### Server
+context = zmq$Context()
+server_socket = context$socket("ZMQ_REP")
+server_socket$bind("tcp://*:55555")
+
+### Client
+context = zmq$Context()
+client_socket = context$socket("ZMQ_REQ")
+client_socket$connect("tcp://localhost:55555")
+
+
+client_socket$send("test")
+c2s <- server_socket$receive()
+
+stopifnot(all.equal(c2s, "test"))
+
+
+server_socket$send("ok")
+s2c <- client_socket$receive()
+
+stopifnot(all.equal(s2c, "ok"))


### PR DESCRIPTION
- Changed `REprintf()` to `warning()`, and guarded the finalizers with `tryCatch()`
- Updated readme.
- Added a basic test.
