### PR TITLE
Fixed .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@
 language: c
 
 before_install:
+  - sudo apt-get install -qq libzmq3-dev
   - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
   - chmod 755 ./travis-tool.sh
   - ./travis-tool.sh bootstrap
-  - sudo apt-get install -qq libzmq-dev
 
 install:
   - ./travis-tool.sh install_deps


### PR DESCRIPTION
There was a problem with the previous .travis.yml, which has been corrected. 

You need to enable travis-ci for the repository.  Actually, if you're eventually going to move it over to @RBigData, you should do that first then enable it on travis' end.
