### PR TITLE
better zmq.version

### DIFF
--- a/R/R_zmq_utility.r
+++ b/R/R_zmq_utility.r
@@ -52,7 +52,7 @@ zmq.strerror <- function(errno){
 #' @rdname xx_utility
 #' @export
 zmq.version <- function(){
-  .Call("R_zmq_version", PACKAGE = "pbdZMQ")
-  invisible()
+  ret <- .Call("R_zmq_version", PACKAGE = "pbdZMQ")
+  package_version(ret)
 }
 

--- a/src/R_zmq_utility.c
+++ b/src/R_zmq_utility.c
@@ -26,9 +26,18 @@ SEXP R_zmq_strerror(SEXP R_errno){
 /* Version. */
 SEXP R_zmq_version(){
 	int major, minor, patch;
+	char ver[5];
+	SEXP ret;
 	
 	zmq_version(&major, &minor, &patch);
-	Rprintf("Current ZeroMQ version is %d.%d.%d\n", major, minor, patch);
-
-	return(R_NilValue);
+	//Rprintf("Current ZeroMQ version is %d.%d.%d\n", major, minor, patch);
+	
+	sprintf(ver, "%d.%d.%d", major, minor, patch);
+	
+	ret = PROTECT(allocVector(STRSXP, 1));
+	SET_STRING_ELT(ret, 0, mkCharLen(ver, 5));
+	
+	UNPROTECT(1);
+	return(ret);
 } /* End of R_zmq_version(). */
+


### PR DESCRIPTION
`zmq.version()` now returns an object of class `package_version`.  I may actually need this for error checking in the client/server, so this isn't just for fun.
