### PR TITLE
Fix internal ZMQ setting.

### DIFF
--- a/configure
+++ b/configure
@@ -1720,7 +1720,7 @@ R_SCMD="${R_HOME}/bin/Rscript -e"
 
 # Check whether --enable-internal-zmq was given.
 if test "${enable_internal_zmq+set}" = set; then :
-  enableval=$enable_internal_zmq; ENABLE_INTERNAL_ZMQ="yes"
+  enableval=$enable_internal_zmq; ENABLE_INTERNAL_ZMQ=$enableval
 else
   ENABLE_INTERNAL_ZMQ="no"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ R_SCMD="${R_HOME}/bin/Rscript -e"
 dnl Check if force enable internal ZeroMQ.
 AC_ARG_ENABLE(internal-zmq,
   AC_HELP_STRING([--enable-internal-zmq], [Enable internal ZeroMQ, default no.]),
-  [ENABLE_INTERNAL_ZMQ="yes"], [ENABLE_INTERNAL_ZMQ="no"])
+  [ENABLE_INTERNAL_ZMQ=$enableval], [ENABLE_INTERNAL_ZMQ="no"])
 
 dnl Check system ZMQ with pkg-config
 GET_PKG_CONFIG="no"


### PR DESCRIPTION
The third argument to `AC_ARG_ENABLE` is action-if-specified, not action-if-true.