### PR TITLE
Minor fix for macOS usernames with whitespaces.

### DIFF
--- a/R/zzz.r.in
+++ b/R/zzz.r.in
@@ -26,6 +26,7 @@
 
         ### Get id from libzmq.*.dylib.
         fn.dylib <- paste(dn, files, sep = "")
+	fn.dylib <- gsub(' ', '\\\\ ', fn.dylib)
         id <- system(paste(cmd.ot, " -D ", fn.dylib, sep = ""),
                      intern = TRUE)
 


### PR DESCRIPTION
On macOS, on the (rare, but existing) occasion when the user's home folder's name contains one or more whitespaces, the otool command is badly set up as those spaces are not escaped (e.g. "otool -D /home/user name/path"), resulting in the impossibility to use pbdZMQ.

This one-line commit fixes the issue (which I encountered recently and fixed by altering the local copy of pbdZMQ's source code before installing it).