### PR TITLE
Add REP/REQ and REQ/REP socket support in sendfile/recvfile

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-04-01: Ver 0.3-4
+  * Support REQ/REP sockets in sendfile/recvfile functions.
+
 2019-02-18: Ver 0.3-4
   * Add "R/R_zmq_transfers.r" for transferfing files and directories.
   * Add importFrom utils for zip and unzip.

--- a/R/R_zmq_socket.r
+++ b/R/R_zmq_socket.r
@@ -115,6 +115,7 @@ NULL
 #' @export
 zmq.socket <- function(ctx, type = .pbd_env$ZMQ.ST$REP){
   ret <- .Call("R_zmq_socket", ctx, type, PACKAGE = "pbdZMQ")
+  attr(ret, "type") = type
   ### Users are responsible to take care free and gc.
   # reg.finalizer(ret, zmq.close, TRUE)
   ret

--- a/R/R_zmq_transfer.r
+++ b/R/R_zmq_transfer.r
@@ -68,6 +68,7 @@
 NULL
 
 
+
 # -----------------------------------------------------------------------------
 # Send
 # -----------------------------------------------------------------------------
@@ -101,7 +102,7 @@ zmq.sendfile <- function(port, filename, verbose=FALSE,
   
   type = attr(socket, "type")
   if (is.null(type))
-    stop("unable to determine socket type; you may need to update pbdZMQ on the client and server")
+    stop("unable to determine socket type")
   else if (type != .pbd_env$ZMQ.ST$PUSH && type != .pbd_env$ZMQ.ST$REQ)
     stop("socket type must be one of PUSH or REQ (matching PULL and REP respectively in zmq.recvfile())")
   
@@ -127,7 +128,6 @@ zmq.sendfile <- function(port, filename, verbose=FALSE,
   
   invisible(ret)
 }
-
 
 
 
@@ -164,7 +164,7 @@ zmq.recvfile <- function(port, endpoint, filename, verbose=FALSE,
   
   type = attr(socket, "type")
   if (is.null(type))
-    stop("unable to determine socket type; you may need to update pbdZMQ on the client and server")
+    stop("unable to determine socket type")
   else if (type != .pbd_env$ZMQ.ST$PULL && type != .pbd_env$ZMQ.ST$REP)
     stop("socket type must be one of PULL or REP (matching PUSH and REQ respectively in zmq.sendfile())")
   

--- a/R/R_zmq_transfer.r
+++ b/R/R_zmq_transfer.r
@@ -4,8 +4,11 @@
 #' to transfer a file in 200 KiB chunks.
 #' 
 #' @details
-#' \code{zmq.sendfile()} binds a \code{ZMQ_PUSH} socket, and 
-#' \code{zmq.recvfile()} connects to this with a \code{ZMQ_PULL} socket.
+#' If no socket is passed, then by default \code{zmq.sendfile()} binds a
+#' \code{ZMQ_PUSH} socket, and \code{zmq.recvfile()} connects to this with a
+#' \code{ZMQ_PULL} socket. On the other hand, a PUSH/PULL or REQ/REP socket
+#' combination may be passed. In that case, the socket should already be
+#' connected to the desired endpoint.
 #' 
 #' @param port 
 #' A valid tcp port.
@@ -72,41 +75,51 @@ zmq.sendfile <- function(port, filename, verbose=FALSE,
                          flags = .pbd_env$ZMQ.SR$BLOCK,
                          forcebin = FALSE, ctx = NULL, socket = NULL)
 {
-  if (is.null(ctx))
-  {
-    ctx <- zmq.ctx.new()
-    ctx.destroy <- TRUE
-  }
-  else
-    ctx.destroy <- FALSE
-
   if (is.null(socket))
   {
+    if (is.null(ctx))
+    {
+      ctx <- zmq.ctx.new()
+      ctx.destroy <- TRUE
+    }
+    else
+      ctx.destroy <- FALSE
+    
     socket <- zmq.socket(ctx, .pbd_env$ZMQ.ST$PUSH)
     socket.close <- TRUE
+    
+    endpoint <- address("*", port)
+    zmq.bind(socket, endpoint)
   }
   else
+  {
+    type = attr(socket, "type")
+    if (is.null(type))
+      stop("unable to determine socket type; you may need to update pbdZMQ on the client and server")
+    else if (type != .pbd_env$ZMQ.ST$PUSH && type != .pbd_env$ZMQ.ST$REQ)
+      stop("socket type must be one of PUSH or REQ (matching PULL and REP respectively in zmq.recvfile())")
+    
+    ctx.destroy <- FALSE
     socket.close <- FALSE
-
-  endpoint <- address("*", port)
-  zmq.bind(socket, endpoint)
+  }
   
   fi <- file.info(filename)
   if (!is.na(fi$isdir) && !fi$isdir)
   {
     filesize <- as.double(fi$size)
     send.socket(socket, filesize)
-  
+    
+    if (type == .pbd_env$ZMQ.ST$REQ)
+      receive.socket(socket)
+    
     ret <- .Call("R_zmq_send_file", socket, filename, as.integer(verbose),
-                 filesize, as.integer(flags), as.integer(forcebin),
-                 PACKAGE = "pbdZMQ")
+      filesize, as.integer(flags), as.integer(forcebin), type, PACKAGE="pbdZMQ")
   }
   else
     stop(paste("File does not exist:", filename)) 
   
   if (socket.close || ctx.destroy)
     zmq.close(socket)
-
   if (ctx.destroy)
     zmq.ctx.destroy(ctx)
   
@@ -121,34 +134,43 @@ zmq.recvfile <- function(port, endpoint, filename, verbose=FALSE,
                          flags = .pbd_env$ZMQ.SR$BLOCK,
                          forcebin = FALSE, ctx = NULL, socket = NULL)
 {
-  if (is.null(ctx))
-  {
-    ctx <- zmq.ctx.new()
-    ctx.destroy <- TRUE
-  }
-  else
-    ctx.destroy <- FALSE
-
   if (is.null(socket))
   {
+    if (is.null(ctx))
+    {
+      ctx <- zmq.ctx.new()
+      ctx.destroy <- TRUE
+    }
+    else
+      ctx.destroy <- FALSE
+    
     socket <- zmq.socket(ctx, .pbd_env$ZMQ.ST$PULL)
     socket.close <- TRUE
+    
+    endpoint <- address(endpoint, port)
+    zmq.connect(socket, endpoint)
   }
   else
+  {
+    type = attr(socket, "type")
+    if (is.null(type))
+      stop("unable to determine socket type; you may need to update pbdZMQ on the client and server")
+    else if (type != .pbd_env$ZMQ.ST$PULL && type != .pbd_env$ZMQ.ST$REP)
+      stop("socket type must be one of PULL or REP (matching PUSH and REQ respectively in zmq.sendfile())")
+    
+    ctx.destroy <- FALSE
     socket.close <- FALSE
+  }
 
-  endpoint <- address(endpoint, port)
-  zmq.connect(socket, endpoint)
-  
   filesize <- receive.socket(socket)
+  if (type == .pbd_env$ZMQ.ST$REP)
+    send.socket(socket, NULL)
   
   ret <- .Call("R_zmq_recv_file", socket, filename, as.integer(verbose),
-               filesize, as.integer(flags), as.integer(forcebin),
-               PACKAGE = "pbdZMQ")
+    filesize, as.integer(flags), as.integer(forcebin), type, PACKAGE="pbdZMQ")
 
   if (socket.close || ctx.destroy)
     zmq.close(socket)
-
   if (ctx.destroy)
     zmq.ctx.destroy(ctx)
   

--- a/R/R_zmq_transfer.r
+++ b/R/R_zmq_transfer.r
@@ -93,15 +93,15 @@ zmq.sendfile <- function(port, filename, verbose=FALSE,
   }
   else
   {
-    type = attr(socket, "type")
-    if (is.null(type))
-      stop("unable to determine socket type; you may need to update pbdZMQ on the client and server")
-    else if (type != .pbd_env$ZMQ.ST$PUSH && type != .pbd_env$ZMQ.ST$REQ)
-      stop("socket type must be one of PUSH or REQ (matching PULL and REP respectively in zmq.recvfile())")
-    
     ctx.destroy <- FALSE
     socket.close <- FALSE
   }
+  
+  type = attr(socket, "type")
+  if (is.null(type))
+    stop("unable to determine socket type; you may need to update pbdZMQ on the client and server")
+  else if (type != .pbd_env$ZMQ.ST$PUSH && type != .pbd_env$ZMQ.ST$REQ)
+    stop("socket type must be one of PUSH or REQ (matching PULL and REP respectively in zmq.recvfile())")
   
   fi <- file.info(filename)
   if (!is.na(fi$isdir) && !fi$isdir)
@@ -152,16 +152,16 @@ zmq.recvfile <- function(port, endpoint, filename, verbose=FALSE,
   }
   else
   {
-    type = attr(socket, "type")
-    if (is.null(type))
-      stop("unable to determine socket type; you may need to update pbdZMQ on the client and server")
-    else if (type != .pbd_env$ZMQ.ST$PULL && type != .pbd_env$ZMQ.ST$REP)
-      stop("socket type must be one of PULL or REP (matching PUSH and REQ respectively in zmq.sendfile())")
-    
     ctx.destroy <- FALSE
     socket.close <- FALSE
   }
-
+  
+  type = attr(socket, "type")
+  if (is.null(type))
+    stop("unable to determine socket type; you may need to update pbdZMQ on the client and server")
+  else if (type != .pbd_env$ZMQ.ST$PULL && type != .pbd_env$ZMQ.ST$REP)
+    stop("socket type must be one of PULL or REP (matching PUSH and REQ respectively in zmq.sendfile())")
+  
   filesize <- receive.socket(socket)
   if (type == .pbd_env$ZMQ.ST$REP)
     send.socket(socket, NULL)

--- a/R/R_zmq_transfer.r
+++ b/R/R_zmq_transfer.r
@@ -68,12 +68,14 @@
 NULL
 
 
+# -----------------------------------------------------------------------------
+# Send
+# -----------------------------------------------------------------------------
 
 #' @rdname b1_sendrecvfile
 #' @export
 zmq.sendfile <- function(port, filename, verbose=FALSE,
-                         flags = .pbd_env$ZMQ.SR$BLOCK,
-                         forcebin = FALSE, ctx = NULL, socket = NULL)
+  flags = .pbd_env$ZMQ.SR$BLOCK, forcebin = FALSE, ctx = NULL, socket = NULL)
 {
   if (is.null(socket))
   {
@@ -128,11 +130,15 @@ zmq.sendfile <- function(port, filename, verbose=FALSE,
 
 
 
+
+# -----------------------------------------------------------------------------
+# Receive
+# -----------------------------------------------------------------------------
+
 #' @rdname b1_sendrecvfile
 #' @export
 zmq.recvfile <- function(port, endpoint, filename, verbose=FALSE,
-                         flags = .pbd_env$ZMQ.SR$BLOCK,
-                         forcebin = FALSE, ctx = NULL, socket = NULL)
+  flags = .pbd_env$ZMQ.SR$BLOCK, forcebin = FALSE, ctx = NULL, socket = NULL)
 {
   if (is.null(socket))
   {

--- a/src/R_zmq.h
+++ b/src/R_zmq.h
@@ -41,8 +41,10 @@ SEXP R_zmq_recv_char(SEXP R_socket, SEXP R_len, SEXP R_flags);
 SEXP R_zmq_recv_raw(SEXP R_socket, SEXP R_len, SEXP R_flags);
 
 /* File transfer */
-SEXP R_zmq_send_file(SEXP R_socket, SEXP R_filename, SEXP verbose_, SEXP filesize_, SEXP R_flags, SEXP R_forcebin);
-SEXP R_zmq_recv_file(SEXP R_socket, SEXP R_filename, SEXP verbose_, SEXP filesize_, SEXP R_flags, SEXP R_forcebin);
+SEXP R_zmq_send_file(SEXP R_socket, SEXP R_filename, SEXP verbose,
+	SEXP filesize_, SEXP R_flags, SEXP R_forcebin, SEXP type_);
+SEXP R_zmq_recv_file(SEXP R_socket, SEXP R_filename, SEXP verbose,
+	SEXP filesize, SEXP R_flags, SEXP R_forcebin, SEXP type_);
 
 /* Utility related. */
 SEXP AsInt(int x);

--- a/src/R_zmq_transfer.c
+++ b/src/R_zmq_transfer.c
@@ -86,6 +86,9 @@ static inline void send_file(file_t *f, void *socket, void *buf, int flags, int 
   
   do
   {
+    if (type == ZMQ_REP)
+      zmq_recv(socket, buf, 1, flags);
+    
     size = fread(buf, 1, BUFLEN, f->file);
     total_size += size;
     
@@ -164,6 +167,9 @@ static inline void recv_file(file_t *f, void *socket, void *buf, int flags, int 
   
   do
   {
+    if (type == ZMQ_REQ)
+      zmq_send(socket, buf, 1, flags);
+    
     int expected_size = zmq_recv(socket, buf, BUFLEN, flags);
     transfer_check(expected_size, "receive", buf, f->file);
     size = (size_t) expected_size;

--- a/src/R_zmq_transfer.c
+++ b/src/R_zmq_transfer.c
@@ -2,11 +2,20 @@
 #include <stdint.h>
 
 // 200 KiB
-#define BUFLEN 204800
+#define BUFLEN 2// 204800
 
-#define BARLEN 30
-#define SCALE 1024
+#define PROGRESS_BARLEN 30
+#define PROGRESS_SCALE 1024
 static const char *memnames[] = {"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"};
+
+typedef struct file_t
+{
+  char *filename;
+  FILE *file;
+  double filesize;
+  int verbose;
+} file_t;
+
 
 static inline int progress_init(const int verbose, double total)
 {
@@ -15,32 +24,34 @@ static inline int progress_init(const int verbose, double total)
   
   if (!verbose) return -1;
   
-  while (total >= SCALE)
+  while (total >= PROGRESS_SCALE)
   {
-    total /= (double) SCALE;
+    total /= (double) PROGRESS_SCALE;
     ind++;
   }
   
   Rprintf("[");
-  for (i=0; i<BARLEN; i++)
+  for (i=0; i<PROGRESS_BARLEN; i++)
     Rprintf("-");
   
   Rprintf("] 0 / %.3f %s", total, memnames[ind]);
   return ind;
 }
 
+
+
 static inline void progress_update(const int verbose, const double current, const double total, const int ind)
 {
   int i;
-  int len = (int) BARLEN*(current/total);
-  double divby = 1./pow(SCALE, ind);
+  int len = (int) PROGRESS_BARLEN*(current/total);
+  double divby = 1./pow(PROGRESS_SCALE, ind);
   
   if (!verbose) return;
   
   Rprintf("\r[");
   for (i=0; i<len; i++)
     Rprintf("#");
-  for (i=len+1; i<BARLEN; i++)
+  for (i=len+1; i<PROGRESS_BARLEN; i++)
     Rprintf("-");
   
   Rprintf("] %.2f / %.2f %s", current*divby, total*divby, memnames[ind]);
@@ -48,53 +59,86 @@ static inline void progress_update(const int verbose, const double current, cons
 
 
 
-SEXP R_zmq_send_file(SEXP R_socket, SEXP R_filename, SEXP verbose_, SEXP filesize_, SEXP R_flags, SEXP R_forcebin){
-  SEXP ret;
-  int ind;
-  const int verbose = INTEGER(verbose_)[0];
-  const double filesize = REAL(filesize_)[0];
-  size_t size;
-  uint64_t total_size = 0;
-  int info = -1, C_errno;
-  int C_flags = INTEGER(R_flags)[0];
-  void *C_socket = R_ExternalPtrAddr(R_socket);
-  FILE *infile;
-  void *buf = malloc(BUFLEN);
-  
-  if (INTEGER(R_forcebin)[0] == 0)
-    infile = fopen(CHARPT(R_filename, 0), "r");
-  else
-    infile = fopen(CHARPT(R_filename, 0), "r+b");
+static inline void transfer_check(int info, char *kind, void *buf, FILE *infile)
+{
+  if (info == -1)
+  {
+    free(buf);
+    fclose(infile);
+    int C_errno = zmq_errno();
+    error("could not %s data:  %d strerror: %s\n", kind, C_errno, zmq_strerror(C_errno));
+  }
+}
 
-  if (infile == NULL)
-    error("Could not open file: %s", CHARPT(R_filename, 0));
+
+
+// ----------------------------------------------------------------------------
+// Send
+// ----------------------------------------------------------------------------
+
+static inline void send_file(file_t *f, void *C_socket, void *buf, int C_flags)
+{
+  uint64_t total_size = 0;
+  size_t size;
   
-  if (buf == NULL)
-    error("Could not allocate temporary buffer");
-  
-  ind = progress_init(verbose, filesize);
+  int ind = progress_init(f->verbose, f->filesize);
   
   do
   {
-    size = fread(buf, 1, BUFLEN, infile);
+    size = fread(buf, 1, BUFLEN, f->file);
     total_size += size;
     
-    if (size < BUFLEN && !feof(infile))
-      error("Error reading from file: %s", CHARPT(R_filename, 0));
+    if (size < BUFLEN && !feof(f->file))
+      error("Error reading from file: %s", f->filename);
     
-    info = zmq_send(C_socket, buf, size, C_flags);
-    if (info == -1){
-      C_errno = zmq_errno();
-      error("could not send data:  %d strerror: %s\n", C_errno, zmq_strerror(C_errno));
-    }
-    
-    progress_update(verbose, (double) total_size, filesize, ind);
+    int info = zmq_send(C_socket, buf, size, C_flags);
+    transfer_check(info, "send", buf, f->file);
+    progress_update(f->verbose, (double) total_size, f->filesize, ind);
     
   } while (size == BUFLEN);
+}
+
+
+
+SEXP R_zmq_send_file(SEXP R_socket, SEXP R_filename, SEXP verbose,
+  SEXP filesize, SEXP R_flags, SEXP R_forcebin, SEXP type_)
+{
+  SEXP ret;
+  int C_flags = INTEGER(R_flags)[0];
+  void *C_socket = R_ExternalPtrAddr(R_socket);
+  char *filename = CHARPT(R_filename, 0);
+  int type = INTEGER(type_)[0];
+  
+  void *buf = malloc(BUFLEN);
+  if (buf == NULL)
+    error("Could not allocate temporary buffer");
+  
+  char *mode = (INTEGER(R_forcebin)[0] == 0) ? "r" : "r+b";
+  FILE *infile = fopen(filename, mode);
+  if (infile == NULL)
+  {
+    free(buf);
+    error("Could not open file: %s", filename);
+  }
+  
+  file_t f;
+  f.filename = filename;
+  f.file = infile;
+  f.filesize = REAL(filesize)[0];
+  f.verbose = INTEGER(verbose)[0];
+  
+  if (type == ZMQ_PUSH)
+    send_file(&f, C_socket, buf, C_flags);
+  else if (type == ZMQ_REQ)
+  {
+    send_file(&f, C_socket, buf, C_flags | ZMQ_SNDMORE);
+    zmq_recv(C_socket, buf, 1, C_flags);
+  }
   
   free(buf);
   fclose(infile);
-  Rprintf("\n");
+  if (f.verbose)
+    Rprintf("\n");
   
   PROTECT(ret = allocVector(INTSXP, 1));
   INTEGER(ret)[0] = 0;
@@ -104,59 +148,80 @@ SEXP R_zmq_send_file(SEXP R_socket, SEXP R_filename, SEXP verbose_, SEXP filesiz
 
 
 
-SEXP R_zmq_recv_file(SEXP R_socket, SEXP R_filename, SEXP verbose_, SEXP filesize_, SEXP R_flags, SEXP R_forcebin)
-{
-  SEXP ret;
-  int ind;
-  const int verbose = INTEGER(verbose_)[0];
-  const double filesize = REAL(filesize_)[0];
-  int expected_size, size;
-  uint64_t total_size = 0;
-  int C_errno;
-  int C_flags = INTEGER(R_flags)[0];
-  void *C_socket = R_ExternalPtrAddr(R_socket);
-  FILE *outfile;
-  void *buf = malloc(BUFLEN);
-  
-  if (INTEGER(R_forcebin)[0] == 0)
-    outfile = fopen(CHARPT(R_filename, 0), "w");
-  else
-    outfile = fopen(CHARPT(R_filename, 0), "w+b");
 
-  if (outfile == NULL)
-    error("Could not open file: %s", CHARPT(R_filename, 0));
+// ----------------------------------------------------------------------------
+// Receive
+// ----------------------------------------------------------------------------
+
+static inline void recv_file(file_t *f, void *C_socket, void *buf, int C_flags)
+{
+  uint64_t total_size = 0;
+  size_t size;
   
-  if (buf == NULL)
-    error("Could not allocate temporary buffer");
-  
-  ind = progress_init(verbose, filesize);
+  int ind = progress_init(f->verbose, f->filesize);
   
   do
   {
-    size = zmq_recv(C_socket, buf, BUFLEN, C_flags);
-    if(size == -1){
-      C_errno = zmq_errno();
-      error("could not send data:  %d strerror: %s\n", C_errno, zmq_strerror(C_errno));
-    }
+    int expected_size = zmq_recv(C_socket, buf, BUFLEN, C_flags | ZMQ_SNDMORE);
+    transfer_check(expected_size, "receive", buf, f->file);
+    size = (size_t) expected_size;
     
     if (size > BUFLEN) /* Truncated data. Error? */
       size = BUFLEN;
     
     total_size += size;
-    expected_size=size;
     
-    size = fwrite(buf, 1, size, outfile);
+    size = fwrite(buf, 1, size, f->file);
     
-    if (size < expected_size)
-      error("Could not write to file: %s", CHARPT(R_filename, 0));
+    if (expected_size < 0 || size < (size_t)expected_size)
+    {
+      free(buf);
+      fclose(f->file);
+      error("Could not write to file: %s", f->filename);
+    }
     
-    progress_update(verbose, (double) total_size, filesize, ind);
+    progress_update(f->verbose, (double) total_size, f->filesize, ind);
     
   } while (size == BUFLEN);
+}
+
+
+
+SEXP R_zmq_recv_file(SEXP R_socket, SEXP R_filename, SEXP verbose,
+  SEXP filesize_, SEXP R_flags, SEXP R_forcebin, SEXP type_)
+{
+  SEXP ret;
+  int C_flags = INTEGER(R_flags)[0];
+  void *C_socket = R_ExternalPtrAddr(R_socket);
+  char *filename = CHARPT(R_filename, 0);
+  int type = INTEGER(type_)[0];
+  
+  void *buf = malloc(BUFLEN);
+  if (buf == NULL)
+    error("Could not allocate temporary buffer");
+  
+  char *mode = (INTEGER(R_forcebin)[0] == 0) ? "w" : "w+b";
+  FILE *outfile = fopen(filename, mode);
+  if (outfile == NULL)
+  {
+    free(buf);
+    error("Could not open file: %s", CHARPT(R_filename, 0));
+  }
+  
+  file_t f;
+  f.filename = filename;
+  f.file = outfile;
+  f.filesize = REAL(filesize_)[0];
+  f.verbose = INTEGER(verbose)[0];
+  
+  recv_file(&f, C_socket, buf, C_flags);
+  if (type == ZMQ_REP)
+    zmq_send(C_socket, buf, 1, C_flags);
   
   free(buf);
   fclose(outfile);
-  Rprintf("\n");
+  if (f.verbose)
+    Rprintf("\n");
   
   PROTECT(ret = allocVector(INTSXP, 1));
   INTEGER(ret)[0] = 0;

--- a/src/zzz.c
+++ b/src/zzz.c
@@ -29,8 +29,8 @@ static const R_CallMethodDef callMethods[] = {
 	{"R_zmq_recv_raw", (DL_FUNC) &R_zmq_recv_raw, 3},
 
 	/* In file "R_zmq_transfer.c". */
-	{"R_zmq_send_file", (DL_FUNC) &R_zmq_send_file, 6},
-	{"R_zmq_recv_file", (DL_FUNC) &R_zmq_recv_file, 6},
+	{"R_zmq_send_file", (DL_FUNC) &R_zmq_send_file, 7},
+	{"R_zmq_recv_file", (DL_FUNC) &R_zmq_recv_file, 7},
 
 	/* In file "R_zmq_utility.c". */
 	{"R_zmq_strerror", (DL_FUNC) &R_zmq_strerror, 1},


### PR DESCRIPTION
Ok, so this is a little bit complicated.

The added support is needed for file transfers in remoter. The existing `zmq.sendfile()` and `zmq.recvfile()` behavior is largely the same, and should be identical with default arguments. There is some very slightly different behavior when passing your own sockets. Before the sockets had to be PUSH/PULL, but now REQ/REP and REP/REQ are supported (see examples below). All of this is documented in the `@details` section. 

I was not able to run `roxygen2::roxygenize()` for some reason, so you will need to update the documentation.

## PUSH/PULL

Send:
```r
suppressMessages(library(pbdZMQ))

port = 55555
f = "/tmp/in"

zmq.sendfile(port, f, verbose=TRUE)
cat("send done\n")
```

Receive:
```r
suppressMessages(library(pbdZMQ))

port = 55555
f = "/tmp/out"

zmq.recvfile(port, "localhost", f)
```

## REQ/REP

Send:
```r
suppressMessages(library(pbdZMQ))

port = 55555
f = "/tmp/in"

ctx = zmq.ctx.new()
socket = zmq.socket(ctx, .pbd_env$ZMQ.ST$REQ)
endpoint = address("*", port)
zmq.bind(socket, endpoint)

zmq.sendfile(file=f, socket=socket, verbose=TRUE)
cat("send done\n")
```

Receive:
```r
suppressMessages(library(pbdZMQ))

port = 55555
f = "/tmp/out"

ctx = init.context()
socket = zmq.socket(ctx, .pbd_env$ZMQ.ST$REP)
endpoint = address("localhost", port)
zmq.connect(socket, endpoint)

zmq.recvfile(filename=f, socket=socket)
zmq.close(socket)
```

## REP/REQ

Send:
```r
suppressMessages(library(pbdZMQ))

port = 55555
f = "/tmp/in"

ctx = zmq.ctx.new()
socket = zmq.socket(ctx, .pbd_env$ZMQ.ST$REP)
endpoint = address("localhost", port)
zmq.connect(socket, endpoint)

zmq.sendfile(file=f, socket=socket, verbose=TRUE)
cat("send done\n")
```

Receive:
```r
suppressMessages(library(pbdZMQ))

port = 55555
f = "/tmp/out"

ctx = init.context()
socket = zmq.socket(ctx, .pbd_env$ZMQ.ST$REQ)
endpoint = address("*", port)
zmq.bind(socket, endpoint)

zmq.recvfile(filename=f, socket=socket)
zmq.close(socket)
```