### PR TITLE
Update msg.cpp

### DIFF
--- a/src/zmqsrc/src/msg.cpp
+++ b/src/zmqsrc/src/msg.cpp
@@ -557,7 +557,7 @@ int zmq::msg_t::set_group (const char * group_, size_t length_)
         return -1;
     }
 
-    strncpy (u.base.group, group_, length_);
+    memcpy (u.base.group, group_, length_);
     u.base.group[length_] = '\0';
 
     return 0;


### PR DESCRIPTION
Fixed an error with gcc8: 

In member function 'int zmq::msg_t::set_group(const char*, size_t)', inlined from 'int zmq::msg_t::set_group(const char*)' at src/msg.cpp:549:22:
src/msg.cpp:560:13: error: 'char* strncpy(char*, const char*, size_t)' output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
  560 |     strncpy (u.base.group, group_, length_);