### PR TITLE
support for serialize version code

### DIFF
--- a/R/R_zmq_message.r
+++ b/R/R_zmq_message.r
@@ -16,6 +16,10 @@
 #' if serialize the \code{rmsg}
 #' @param unserialize 
 #' if unserialize the received R message
+#' @param serialversion
+#' NULL or numeric; the workspace format version to use when serializing.
+#' NULL specifies the current default version. The only other supported
+#' values are 2 and 3
 #' 
 #' @return \code{zmq.msg.send()} returns 0 if successful, otherwise returns -1
 #' and sets \code{errno} to \code{EFAULT}.
@@ -85,9 +89,9 @@ zmq.msg.close <- function(msg.t){
 #' @rdname a2_message
 #' @export
 zmq.msg.send <- function(rmsg, socket, flags = .pbd_env$ZMQ.SR$BLOCK,
-                         serialize = TRUE){
+                         serialize = TRUE, serialversion = NULL){
   if(serialize){
-    rmsg <- serialize(rmsg, NULL)
+    rmsg <- serialize(rmsg, NULL, version = serialversion)
   }
   ret <- .Call("R_zmq_msg_send", rmsg, socket, as.integer(flags), PACKAGE = "pbdZMQ")
   invisible(ret)

--- a/R/rzmq_wrapper.r
+++ b/R/rzmq_wrapper.r
@@ -29,6 +29,10 @@
 #' @param serialize,unserialize
 #' Logical; determines if serialize/unserialize should be called
 #' on the sent/received data.
+#' @param serialversion
+#' NULL or numeric; the workspace format version to use when serializing.
+#' NULL specifies the current default version. The only other supported
+#' values are 2 and 3.
 #' @param dont.wait
 #' Logical; determines if reception is blocking.
 #' @param context
@@ -56,13 +60,15 @@ NULL
 
 #' @rdname xx_rzmq_wrapper
 #' @export
-send.socket <- function(socket, data, send.more = FALSE, serialize = TRUE){
+send.socket <- function(socket, data, send.more = FALSE, serialize = TRUE,
+                        serialversion = NULL){
   if(send.more){
     flags <- .pbd_env$ZMQ.SR$SNDMORE
   } else{
     flags <- .pbd_env$ZMQ.SR$BLOCK
   }
-  zmq.msg.send(data, socket, flags = flags, serialize = serialize)
+  zmq.msg.send(data, socket, flags = flags, serialize = serialize,
+               serialversion = serialversion)
 }
 
 


### PR DESCRIPTION
The package remoter which depends on package pbdZMQ does not have the capability to transfer data between a server running R version 3.6.1 and a client running R version 3.4.4. The reason is that R 3.6.1 by default serializes with format version 3, which is not readable by R 3.4.4.

<https://www.rdocumentation.org/packages/base/versions/3.6.1/topics/serialize>

I have a set up where I need to do the above transfer and thus I create this pull request.

This commit adds an optional `serialversion` argument to the functions `send.socket` and `zmq.msg.send` that allows finer control of the serialization process. The default value of this argument is NULL and its two other possible values are 2 and 3. The behavior of the code without passing this argument is the same as before. However, when setting `serialversion` to 2, one can transfer data between different versions of R, as mentioned above (also in remoter, with a code change).

The branch feature-serialize_version_old of this pull request has a single commit on top of commit 914b90582bf294e1a311a244b3ff91d9bb44c0a0 which corresponds to version 0.3-3 of the package. Since there is no 0.3-3 branch, I have put the pull request on master of the base repository. (I have to remark though that master seems to now require R version at least 3.5.0.)